### PR TITLE
fixed compiler warning.

### DIFF
--- a/ngx_http_ajp_handler.c
+++ b/ngx_http_ajp_handler.c
@@ -62,7 +62,7 @@ ngx_http_ajp_handler(ngx_http_request_t *r)
     }
 
     a->state = ngx_http_ajp_st_init_state;
-    a->pstate = ngx_http_ajp_st_init_state;
+    a->pstate = ngx_http_ajp_pst_init_state;
 
     ngx_http_set_ctx(r, a, ngx_http_ajp_module);
 


### PR DESCRIPTION
The compiler warning is described below.

```
../nginx_ajp_module/ngx_http_ajp_handler.c:65:17: error: implicit conversion from enumeration type 'ngx_http_ajp_state_e' to different enumeration type
      'ngx_http_ajp_packet_state_e' [-Werror,-Wenum-conversion]
    a->pstate = ngx_http_ajp_st_init_state;
```