### PR TITLE
Add secret support for AJP protocol to solve CVE-2020-1938.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -298,6 +298,14 @@ You may also use an upstream block.
 
         ajp_pass   backend;
 
+## ajp\_secret
+
+__syntax:__ _ajp\_secret ajpsecret
+
+__default:__ _none_
+
+Directive assigns the secret of the AJP-server. 
+        
 ## ajp\_pass\_header
 
 __syntax:__ _ajp\_pass\_header name;_

--- a/ngx_http_ajp.c
+++ b/ngx_http_ajp.c
@@ -565,6 +565,18 @@ ajp_marshal_into_msgb(ajp_msg_t *msg,
         }
     }
 
+    // secret
+    ngx_str_t* secret = alcf->secret;
+    if (secret != NULL) {
+        if (ajp_msg_append_uint8(msg, SC_A_SECRET) ||
+                ajp_msg_append_string(msg, secret)) {
+            ngx_log_error(NGX_LOG_ERR, log, 0,
+                          "ajp_marshal_into_msgb: "
+                          "Error appending the secret");
+            return AJP_EOVERFLOW;
+        }
+    }
+
 #if (NGX_HTTP_SSL)
 
     /*

--- a/ngx_http_ajp_module.c
+++ b/ngx_http_ajp_module.c
@@ -12,6 +12,9 @@ static char *ngx_http_ajp_pass(ngx_conf_t *cf, ngx_command_t *cmd,
 static char *ngx_http_ajp_store(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
+static char *ngx_http_ajp_secret(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
 #if (NGX_HTTP_CACHE)
 static char *ngx_http_ajp_cache(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
@@ -88,6 +91,13 @@ static ngx_command_t  ngx_http_ajp_commands[] = {
     { ngx_string("ajp_pass"),
       NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
       ngx_http_ajp_pass,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
+    { ngx_string("ajp_secret"),
+      NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
+      ngx_http_ajp_secret,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
       NULL },
@@ -441,6 +451,19 @@ ngx_http_ajp_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     return NGX_CONF_OK;
 }
 
+static char *
+ngx_http_ajp_secret(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_ajp_loc_conf_t    *alcf = conf;
+    ngx_str_t                  *value, *secret;
+
+    value = cf->args->elts;
+    secret = &value[1];
+    alcf->secret = secret;
+
+    return NGX_CONF_OK;
+}
+
 
 static char *
 ngx_http_ajp_store(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
@@ -737,6 +760,8 @@ ngx_http_ajp_create_loc_conf(ngx_conf_t *cf)
     conf->keep_conn = NGX_CONF_UNSET;
 
     ngx_str_set(&conf->upstream.module, "ajp");
+
+    conf->secret = NULL;
 
     return conf;
 }

--- a/ngx_http_ajp_module.c
+++ b/ngx_http_ajp_module.c
@@ -11,7 +11,6 @@ static char *ngx_http_ajp_pass(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 static char *ngx_http_ajp_store(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
-
 static char *ngx_http_ajp_secret(ngx_conf_t *cf, ngx_command_t *cmd,
     void *conf);
 
@@ -89,7 +88,7 @@ static ngx_str_t  ngx_http_ajp_hide_cache_headers[] = {
 static ngx_command_t  ngx_http_ajp_commands[] = {
 
     { ngx_string("ajp_pass"),
-      NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
+      NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE12,
       ngx_http_ajp_pass,
       NGX_HTTP_LOC_CONF_OFFSET,
       0,
@@ -426,6 +425,10 @@ ngx_http_ajp_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             return NGX_CONF_ERROR;
         }
 
+	if( cf->args->nelts>2 ) {
+            alcf->secret = &value[2];
+	}
+
         return NGX_CONF_OK;
     }
 
@@ -448,6 +451,9 @@ ngx_http_ajp_pass(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         return NGX_CONF_ERROR;
     }
 
+    if( cf->args->nelts>2 ) {
+         alcf->secret = &value[2];
+    }
     return NGX_CONF_OK;
 }
 
@@ -460,7 +466,6 @@ ngx_http_ajp_secret(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     value = cf->args->elts;
     secret = &value[1];
     alcf->secret = secret;
-
     return NGX_CONF_OK;
 }
 

--- a/ngx_http_ajp_module.h
+++ b/ngx_http_ajp_module.h
@@ -23,6 +23,8 @@ typedef struct {
     ngx_http_complex_value_t   cache_key;
 #endif
 
+    ngx_str_t*		       secret;
+
 } ngx_http_ajp_loc_conf_t;
 
 


### PR DESCRIPTION
CVE-2020-1938: Ghostcat - Apache Tomcat AJP File Read/Inclusion Vulnerability (CNVD-2020-10487)
To solve this problem, add secret support.