### PR TITLE
Fixed compatibility with NGINX v1.21.1+

### DIFF
--- a/ngx_http_ajp.c
+++ b/ngx_http_ajp.c
@@ -136,7 +136,7 @@ sc_for_req_get_uri(ngx_http_request_t *r, ngx_str_t *uri)
 
     escape = 0;
 
-    if (r->quoted_uri || r->space_in_uri || r->internal) {
+    if (r->quoted_uri || r->internal)
         escape = 2 * ngx_escape_uri(NULL, r->uri.data,
                 r->uri.len, NGX_ESCAPE_URI);
     }


### PR DESCRIPTION
closes: https://github.com/yaoweibin/nginx_ajp_module/issues/51

Since NGINX removed support for spaces in URIs, we need to remove space_in_uri too.

> From now on, requests with spaces in URIs are immediately rejected rather
than allowed.  Spaces were allowed in 31e9677b15a1 (0.8.41) to handle bad
clients.  It is believed that now this behaviour causes more harm than
good.

https://github.com/nginx/nginx/commit/05395f4889cf0b66e8d049921ad19f1a08319150

Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

cc @yaoweibin 