### PR TITLE
Remove the r->space_in_uri in ngx_http_ajp.c

### DIFF
--- a/ngx_http_ajp.c
+++ b/ngx_http_ajp.c
@@ -136,7 +136,7 @@ sc_for_req_get_uri(ngx_http_request_t *r, ngx_str_t *uri)
 
     escape = 0;
 
-    if (r->quoted_uri || r->space_in_uri || r->internal) {
+    if (r->quoted_uri || r->internal) {
         escape = 2 * ngx_escape_uri(NULL, r->uri.data,
                 r->uri.len, NGX_ESCAPE_URI);
     }

--- a/ngx_http_ajp_msg.c
+++ b/ngx_http_ajp_msg.c
@@ -292,7 +292,7 @@ ngx_int_t
 ajp_msg_get_string(ajp_msg_t *msg, ngx_str_t *value)
 {
     u_char    *start;
-    uint16_t   size;
+    uint16_t   size = 0;
     ngx_int_t  status;
     ngx_buf_t *buf;
 


### PR DESCRIPTION
Remove the r->space_in_uri in ngx_http_ajp.c

Refer:
https://mailman.nginx.org/pipermail/nginx-devel/2021-June/014147.html https://github.com/nginx/nginx/blob/d791b4aab418b0cbadbaf079fbb9360269d97941/src/http/modules/ngx_http_proxy_module.c#L1191